### PR TITLE
fix for prettify not defined error in static builds

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -136,9 +136,6 @@ require.config({
         i18next: {
             deps: ['jquery'],
             exports: 'i18n'
-        },
-        prettify: {
-            exports: 'prettify'
         }
     },
     findNestedDependencies: true,


### PR DESCRIPTION
Fixes issue #148 - built versions of laverna do not load in google-code-prettify, making it impossible to view notes in the right hand pane.

Removes the requirejs shim in main.js - this fixes the error. ( google-code-prettify is AMD compliant so doesn't need to be shimmed - I think, anyway! ) 
