### PR TITLE
Cannot add new note directly after canceling adding a note.

### DIFF
--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -184,6 +184,8 @@ define([
             // Redirect to list
             else if (typeof this.model.get('id') !== 'undefined') {
                 App.AppNote.trigger('navigate:back');
+            } else {
+                window.history.go(-1);
             }
 
             if (showNote !== false) {


### PR DESCRIPTION
Steps to reproduce this bad state:
- Click the button to add a new note. URL changes to /#/notes/add
- Without saving, cancel the note. Notice that URL is still /#/notes/add even though it's now showing the list of notes.
- Click the button to add a new note, and nothing happens because the url is already /#/notes/add

This PR fixes it, however, I'm totally new to laverna and marrionette, so this may not be the appropriate way of doing this. The problem was that new notes do not have an id yet, but this code will not work unless it does have one.
