### PR TITLE
Move notebook title to the side

### DIFF
--- a/app/scripts/apps/notes/show/templates/item.html
+++ b/app/scripts/apps/notes/show/templates/item.html
@@ -53,7 +53,7 @@
                 </div>
             </div>
             <% } %>
-            <p><% if (notebook !== null) { %>{{ notebook }}<% } %></p>
+            <p class="notebooktitle"><% if (notebook !== null) { %>{{ notebook }}<% } %></p>
             {{ getContent() }}
         </div>
     </div>

--- a/app/styles/theme-default/content.less
+++ b/app/styles/theme-default/content.less
@@ -36,6 +36,9 @@
         cursor: pointer;
         color: darken(#FFF, 60%);
     }
+    .notebooktitle {
+        float: right;
+    }
 }
 // Article
 #content .article {


### PR DESCRIPTION
#184 : notebook titles now float on the right, not distracting from the content
