### PR TITLE
added icon & seperator line to Notebook name in Note preview

### DIFF
--- a/app/scripts/apps/notes/show/templates/item.html
+++ b/app/scripts/apps/notes/show/templates/item.html
@@ -53,7 +53,9 @@
                 </div>
             </div>
             <% } %>
-            <p class="notebooktitle"><% if (notebook !== null) { %>{{ notebook }}<% } %></p>
+            <p class="notebooktitle">
+                <% if (notebook !== null) { %><i class="icon-notebook"></i> {{ notebook }}<hr><% } %>
+            </p>
             {{ getContent() }}
         </div>
     </div>


### PR DESCRIPTION
The previous styling of the "Notebook" name in "Note" preview view looks like this:

![screen shot 2015-03-24 at 3 53 29 pm](https://cloud.githubusercontent.com/assets/48677/6805150/bef02ee6-d241-11e4-9e6c-409b56d94b52.png)

My notebook "Essays" was so faint and blended in I almost thought it was part of my note. My proposed solution in this pull request looks like this:

![screen shot 2015-03-24 at 3 54 36 pm](https://cloud.githubusercontent.com/assets/48677/6805162/d21b0482-d241-11e4-901a-b08bceb7e77f.png)

Hopefully y'all like my idea. I believe it better separates the notebook from the UI, it was a bit blending together IMHO... now I think it is more clearly a "UI" element


