### PR TITLE
Fixed typo on Spanish translation.

### DIFF
--- a/app/locales/es/translation.json
+++ b/app/locales/es/translation.json
@@ -61,7 +61,7 @@
     "Newer": "Anterior",
     "Older": "Siguiente",
     "Navigation": "Navegación",
-    "Top": "Superiro",
+    "Top": "Superior",
     "Bottom": "Inferior",
     "Jump": "Saltar",
     "Go to inbox": "Ir a la bandeja de entrada",


### PR DESCRIPTION
Replaced Superiro with Superior.