### PR TITLE
Use previously selected notebook for a new note

### DIFF
--- a/app/scripts/apps/notes/appNote.js
+++ b/app/scripts/apps/notes/appNote.js
@@ -33,8 +33,8 @@ define([
         appRoutes: {
             '': 'showIndex',
             'p/:profile'                    : 'filterNotes',
-            '(p/:profile/)notes/add'        : 'noteForm',
-            '(p/:profile/)notes/edit/:id'   : 'noteForm',
+            '(p/:profile/)notes(/f/:filter)(/q/:query)/add': 'noteForm',
+            '(p/:profile/)notes/edit/:id'   : 'noteEditForm',
             '(p/:profile/)notes(/f/:filter)(/q/:query)(/p:page)': 'filterNotes',
             '(p/:profile/)notes(/f/:filter)(/q/:query)(/p:page)(/show/:id)': 'showNote'
         },
@@ -103,10 +103,17 @@ define([
             });
         },
 
+        // Shows a form for editing
+        noteEditForm: function(profile, id) {
+            this.noteForm(profile, null, null, id );
+        },
+
         // Shows a form for editing or adding notes
-        noteForm: function(profile, id) {
+        noteForm: function(profile, filter, query, id) {
             var args = _.extend(this.notesArg || {}, {
                 id      : id,
+                filter  : filter,
+                query   : query,
                 profile : profile
             });
 
@@ -160,7 +167,16 @@ define([
         // Listen to events
         this.listenTo(Radio.channel('appNote'), 'notes:toggle', API._toggleSidebar);
         this.listenTo(Radio.channel('global'), 'form:show', function() {
-            Radio.request('uri', 'navigate', '/notes/add', {
+
+            // Construct the notes/.../add URI with optional filter/query args.
+            var uri = '/notes';
+            if (API.notesArg && API.notesArg.filter)
+                uri += '/f/' + API.notesArg.filter;
+            if (API.notesArg && API.notesArg.query)
+                uri += '/q/' + API.notesArg.query;
+            uri += '/add';
+
+            Radio.request('uri', 'navigate', uri, {
                 trigger       : true,
                 includeProfile: true
             });

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -72,10 +72,18 @@ define([
             Radio.request('global', 'region:show', 'content', this.view);
             this.view.trigger('rendered');
 
+            // Resolve the notebook ID.
+            // If the current note doesn't have a notebook attached,
+            // try to use one from the filter if it specifies a notebook.
+            var activeId = note.get('notebookId');
+            if (activeId === '0' && this.options.filter == 'notebook') {
+                activeId = this.options.query;
+            }
+
             // Show notebooks selector
             notebooksView = new NotebooksView({
                 collection : notebooks,
-                activeId   : note.get('notebookId')
+                activeId   : activeId
             });
             this.view.notebooks.show(notebooksView);
 


### PR DESCRIPTION
If the user has filtered the sidebar by a notebook before they click the
new note button, the notebook is selected by default for the note.

The filter and query are included in the URI for the `notes/add` route.
The note form will use these two values to figure out which notebook to
pre-select in case the currently edited note doesn't have a notebook
assigned.

Implements #271