### PR TITLE
Select the newly added notebook in notes form

### DIFF
--- a/app/scripts/apps/notebooks/appNotebooks.js
+++ b/app/scripts/apps/notebooks/appNotebooks.js
@@ -1,11 +1,12 @@
 /* global define, requirejs */
 define([
+    'q',
     'underscore',
     'marionette',
     'backbone.radio',
     'app',
     'apps/notebooks/list/app'
-], function(_, Marionette, Radio, App, SidebarApp) {
+], function(Q, _, Marionette, Radio, App, SidebarApp) {
     'use strict';
 
     /**
@@ -90,9 +91,16 @@ define([
 
         // Edit or add notebooks
         notebookForm: function(profile, id) {
+
+            // Return a promise that gets resolved when the new notebook is
+            // successfully created.
+            var defer = Q.defer();
+
             requirejs(['apps/notebooks/form/notebook/app'], function(Module) {
-                startModule(Module, {profile: profile, id: id});
+                startModule(Module, {profile: profile, id: id, promise: defer});
             });
+
+            return defer.promise;
         },
 
         // Edit or add tags

--- a/app/scripts/apps/notes/form/views/notebooks.js
+++ b/app/scripts/apps/notes/form/views/notebooks.js
@@ -44,7 +44,15 @@ define([
 
         addNotebook: function() {
             if (this.ui.notebookId.find('.addNotebook').is(':selected')) {
-                Radio.request('appNotebooks', 'show:form');
+                var self = this;
+                Radio.request('appNotebooks', 'show:form')
+                    .then(function(notebook) {
+
+                        // Set the active notebook if one was created by the user.
+                        if (notebook)
+                            self.ui.notebookId.val(notebook.id);
+                    });
+
                 this.ui.notebookId.val(this.options.activeId);
             }
         }


### PR DESCRIPTION
When the user adds a new notebook while creating/editing an existing
note, the notebook is selected automatically.

The implementation is done by returning a promise from the `appNotebook` `show:form` reply. This promise is passed on to the `form/notebook/app` which resolved it with the new notebook during save or with null value `onDestroy` if it hasn't been resolved previously.

I opted for promises to better target the result as a global request/reply might have changed the drop down notebook value in cases where the user wasn't adding a new notebook through the drop down. Promises guarantee that only notebook forms requested by the notebook view may alter the selected item of the said view.