### PR TITLE
Fix Windows tile image paths in index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -23,10 +23,10 @@
         <!-- Microsoft Windows 8 & Phone start screen tile support -->
         <meta name="application-name" content="Laverna" />
         <meta name="msapplication-TileColor" content="#006C60" />
-        <meta name="msapplication-square70x70logo" content="images/icon/icon70x70.png" />
-        <meta name="msapplication-square150x150logo" content="images/icon/icon150x150.png" />
-        <meta name="msapplication-wide310x150logo" content="images/icon/icon310x150.png" />
-        <meta name="msapplication-square310x310logo" content="images/icon/icon310x310.png" />
+        <meta name="msapplication-square70x70logo" content="images/icon/icon-70x70.png" />
+        <meta name="msapplication-square150x150logo" content="images/icon/icon-150x150.png" />
+        <meta name="msapplication-wide310x150logo" content="images/icon/icon-310x150.png" />
+        <meta name="msapplication-square310x310logo" content="images/icon/icon-310x310.png" />
 
         <link rel="stylesheet" href="styles/core.css">
         <link rel="stylesheet" href="styles/theme-default.css">


### PR DESCRIPTION
Note: Windows caches the tile icons very aggressively. The easiest way to test the effectiveness of this change is to open Laverna with URL such as `http://localhost:9000/?` - the `?` makes Windows consider it a different page and bypasses the cache (once).

Pinning itself can be done in for Edge using "Pin to Start" found in the menu for example.

Fixes #240 