### PR TITLE
update README for installation from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ $ npm install gulp
 #### 4. Install Laverna's dependencies:
 
 ```bash
-$ npm install && bower install
+$ npm install
+$ bower install
+$ (cd test && bower install)
 ```
 
 #### 5. Build minified version of Laverna:


### PR DESCRIPTION
Added `(cd test && bower install)` as a necessary command.
`gulp build` fails otherwise, since it attempts to run mocha tests.