### PR TITLE
Add runtime dependency for the desktop app that is required to open links

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "gulp-uglify": "^1.4.1",
     "jshint-stylish": "^2.1.0",
     "merge-stream": "^1.0.0",
-    "nightwatch": "^0.8.9"
+    "nightwatch": "^0.8.9",
+    "open": "0.0.5"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
Without this, one can package the app with electron successfully - but this app cannot open links (Ugly error message appears instead)