### PR TITLE
Preload to prevent breaking external pages in Electron. Fixes #328, #351

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -6,9 +6,10 @@ var app               = require('app'),
     path              = require('path'),
     menu              = require('menu');
 
-require('electron-debug')({
-    showDevTools: false
-});
+// Uncomment to enable helpful F12 Chrome inspector debugging
+//require('electron-debug')({
+//    showDevTools: false
+//});
 
 // Start server
 require('./server');

--- a/electron.js
+++ b/electron.js
@@ -7,9 +7,11 @@ var app               = require('app'),
     menu              = require('menu');
 
 // Uncomment to enable helpful F12 Chrome inspector debugging
-//require('electron-debug')({
-//    showDevTools: false
-//});
+if(process.env.NODE_ENV === 'dev'){
+	require('electron-debug')({
+	    showDevTools: true
+	});
+}
 
 // Start server
 require('./server');
@@ -72,7 +74,6 @@ app.on('ready', function() {
         width  : 1000,
         height : 600
     });
-
     // Create the browser window.
     mainWindow = new BrowserWindow({
         width                : windowState.width,
@@ -84,7 +85,7 @@ app.on('ready', function() {
             'preload': path.resolve(path.join(__dirname, 'preload.js'))
         },
         'auto-hide-menu-bar' : true,
-        'icon'               : './resources/app/images/icon/icon-120x120.png'
+        'icon'               : path.join(__dirname, '/dist/images/icon/icon-120x120.png')
     });
 
     // Open all external links in a different browser

--- a/electron.js
+++ b/electron.js
@@ -3,7 +3,12 @@
 var app               = require('app'),
     windowStateKeeper = require('electron-window-state'),
     BrowserWindow     = require('browser-window'),
+    path              = require('path'),
     menu              = require('menu');
+
+require('electron-debug')({
+    showDevTools: false
+});
 
 // Start server
 require('./server');
@@ -73,7 +78,10 @@ app.on('ready', function() {
         height               : windowState.height,
         x                    : windowState.x,
         y                    : windowState.y,
-        'node-integration'   : true,
+        'web-preferences':{
+            'node-integration'   : true,
+            'preload': path.resolve(path.join(__dirname, 'preload.js'))
+        },
         'auto-hide-menu-bar' : true,
         'icon'               : './resources/app/images/icon/icon-120x120.png'
     });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,6 +27,11 @@ var gulp         = require('gulp'),
     mocha        = require('gulp-mocha-phantomjs'),
     nightwatch   = require('gulp-nightwatch');
 
+const dev = !!util.env.dev; // Add --dev flag to enable
+
+gulp.task('sup', function () {
+    console.log(dev)
+});
 /**
  * Server for dist folder.
  */
@@ -215,7 +220,7 @@ gulp.task('build:js', ['clean:dist'], function() {
         preserveLicenseComments: true,
         wrap                   : true
     }))
-    .pipe(uglify({
+    .pipe(dev ? util.noop(): uglify({
         preserveComments: 'license'
     }))
     .pipe(gulp.dest('./dist/scripts'));
@@ -250,7 +255,6 @@ gulp.task('cssmin', ['clean:dist'], function() {
  */
 gulp.task('copy:deps', ['clean:dist'], function() {
     var options = {base: './app/bower_components/'};
-
     return merge.apply(merge, [
         gulp.src([
             './LICENSE'
@@ -286,7 +290,7 @@ gulp.task('copy:deps', ['clean:dist'], function() {
             './app/bower_components/dropbox/dropbox.js',
             './app/bower_components/sjcl/sjcl.js',
         ], options)
-        .pipe(uglify({
+        .pipe(dev ? util.noop() : uglify({
             preserveComments: 'license'
         }))
         .pipe(gulp.dest('./dist/bower_components/')),
@@ -443,6 +447,7 @@ gulp.task('copy:release', ['copy:dist'], function() {
         './node_modules/mkdirp/**',
         './node_modules/wordwrap/**',
         './server.js',
+        './preload.js',
         './package.json'
     ], {base: './'})
     .pipe(gulp.dest('./release/laverna'));

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/Laverna/laverna"
   },
   "scripts": {
-    "start": "node ./server.js"
+    "start": "node ./server.js",
+    "electron": "NODE_ENV=dev electron ."
   },
   "main": "electron.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
+    "electron-debug": "^0.5.1",
     "electron-window-state": "^1.1.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^3.0.2",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,9 @@
+// Requirejs compatibility in Electron app
+console.log('Preloading...');
+if (window.require) {
+    window.requireNode = window.require;
+    window.moduleNode  = window.module;
+
+    window.require = undefined;
+    window.module  = undefined;
+}


### PR DESCRIPTION
- Added a `preload.js` script that runs on every `BrowserWindow` for `Electron` compatibility with `RequireJS`
- `Electron` dev tool and a `--dev` flag for unminimised `Gulp` builds