### PR TITLE
Fix padding around header title text

### DIFF
--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -3,7 +3,7 @@
 
     <ul class="nav navbar-nav navbar-left header--col--left">
         <li class="header--col--left--drawer">
-            <a href="#{{args.currentUrl}}" class="btn-link navbar-brand header--title sidemenu--open -text-elipsis">
+            <a href="#{{args.currentUrl}}" class="btn-link header--title sidemenu--open -text-elipsis">
                 <i class="icon-menu header--icon"></i>
                 <span id="header--title" class="hidden-xs hidden-sm">
                     {{i18n(args.title)}}

--- a/app/scripts/apps/settings/sidebar/templates/navbar.html
+++ b/app/scripts/apps/settings/sidebar/templates/navbar.html
@@ -1,13 +1,13 @@
 <nav class="header navbar navbar-default navbar-static-top header--settings -left" id="sidebar--nav">
 <div class="container-fluid">
     <ul class="nav navbar-nav navbar-left">
-        <li class="header--settings--back">
+        <li>
             <a href="#" class="settings--cancel">
                 <i class="icon-left-open-big"></i>
             </a>
         </li>
         <li>
-            <a href="#/settings/general" class="btn-link navbar-brand header--title">
+            <a href="#/settings/general" class="btn-link header--title">
                 {{i18n('Settings')}}
             </a>
         </li>

--- a/app/styles/core/header.less
+++ b/app/styles/core/header.less
@@ -85,9 +85,15 @@
     display: flex;
 }
 
-.navbar > .container-fluid .navbar-brand.header--title {
-    margin-left   : 0;
-    padding-left  : 0;
-    padding-right : 0;
-    width         : 100%;
+/**
+ * Navbar title
+ */
+.header--title {
+    font-size: 18px;
+    margin-left: 0;
+    width: 100%;
+}
+
+#header--title {
+    margin-left: 15px;
 }

--- a/app/styles/core/header.less
+++ b/app/styles/core/header.less
@@ -75,10 +75,6 @@
     .container-fluid  {
         padding-left: 0;
     }
-
-    .header--settings--back {
-        margin-right: 15px;
-    }
 }
 
 .header--container {

--- a/app/styles/theme-default/header.less
+++ b/app/styles/theme-default/header.less
@@ -7,14 +7,13 @@
     border     : @border;
     color      : @color;
 
-    .navbar-brand {
+    .header--title {
         &:hover,
         &:focus {
             background-color: darken(@bg, 5%);
         }
     }
 
-    .navbar-brand,
     .navbar-nav > li > a,
     .navbar-btn,
     .navbar-link,
@@ -36,9 +35,6 @@
 }
 .header--container.-left {
     padding-left: 0;
-}
-.header--icon {
-    padding: 20px;
 }
 .header--search {
     padding-right: 0;


### PR DESCRIPTION
Covers secondary issues brought up in #305, along with some code cleanup.

##### Header Title (before)

![navbar-old](https://cloud.githubusercontent.com/assets/3130334/12213465/f8458cb4-b63d-11e5-9dd6-4dd1dc35717d.png)

##### Header Title (after)

![navbar-new](https://cloud.githubusercontent.com/assets/3130334/12213498/a779b96c-b63e-11e5-8a00-6d129ee5a272.png)

##### Settings Title (before)

![settings-old](https://cloud.githubusercontent.com/assets/3130334/12213471/15c72810-b63e-11e5-83c9-d53a41d88cc3.png)

##### Settings Title (after)

![settings-new](https://cloud.githubusercontent.com/assets/3130334/12213472/1c66944e-b63e-11e5-8d66-3329c2598fcf.png)