### PR TITLE
:bug: fix inline code blocks not showing up inline

### DIFF
--- a/app/styles/theme-default/prism.less
+++ b/app/styles/theme-default/prism.less
@@ -7,6 +7,7 @@
 code,
 pre[class*="language-"] {
     color: black;
+    background-color: #fdfdfd;
     font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
     direction: ltr;
     text-align: left;
@@ -27,14 +28,14 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-code {
+pre > code {
+    display: block;
     position: relative;
     margin: .5em 0;
     -webkit-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
     -moz-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
     box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
     border-left: 10px solid lighten(@color--info, 4%);
-    background-color: #fdfdfd;
     background-image: -webkit-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
     background-image: -moz-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
     background-image: -ms-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
@@ -42,23 +43,21 @@ code {
     background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
     background-size: 3em 3em;
     background-origin: content-box;
-    overflow: visible;
-    max-height: 30em;
-    padding: 0;
-}
-
-code {
+    overflow: auto;
     max-height: inherit;
     height: 100%;
     padding: 0 1em;
-    display: block;
-    overflow: auto;
+}
+
+/* Inline code */
+:not(pre) > code {
+    padding: 0 0.2em;
+    box-shadow: 0px 0px 0px 1px #dfdfdf;
 }
 
 /* Margin bottom to accomodate shadow */
 :not(pre) > code[class*="language-"],
 code {
-    background-color: #fdfdfd;
     -webkit-box-sizing: border-box;
     -moz-box-sizing: border-box;
     box-sizing: border-box;


### PR DESCRIPTION
Inline code blocks were receiving the same style as code fences, thus
showing up on a new line.

Also, some duplicate (conflicting) CSS was removed/merged together.

Fixes #362

**Result**:
![inline-code](https://cloud.githubusercontent.com/assets/3130334/12439932/ff4cc83a-befb-11e5-9cb4-962e54462abb.png)