### PR TITLE
:bug: fix Coy theme for Prism

### DIFF
--- a/app/styles/theme-default/prism.less
+++ b/app/styles/theme-default/prism.less
@@ -28,44 +28,39 @@ pre[class*="language-"] {
 }
 
 /* Code blocks */
-pre > code {
-    display: block;
-    position: relative;
-    margin: .5em 0;
-    -webkit-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-    -moz-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-    box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
-    border-left: 10px solid lighten(@color--info, 4%);
-    background-image: -webkit-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-    background-image: -moz-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-    background-image: -ms-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-    background-image: -o-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-    background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
-    background-size: 3em 3em;
-    background-origin: content-box;
-    overflow: auto;
-    max-height: inherit;
-    height: 100%;
-    padding: 0 1em;
+.-note,
+.editor--preview {
+    pre {
+        display: block;
+        position: relative;
+        margin: .5em 0;
+        -webkit-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
+        -moz-box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
+        box-shadow: -1px 0px 0px 0px #358ccb, 0px 0px 0px 1px #dfdfdf;
+        border-left: 10px solid lighten(@color--info, 4%);
+        background-image: -webkit-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+        background-image: -moz-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+        background-image: -ms-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+        background-image: -o-linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+        background-image: linear-gradient(transparent 50%, rgba(69, 142, 209, 0.04) 50%);
+        background-size: 3em 3em;
+        background-origin: content-box;
+        overflow: visible;
+        max-height: inherit;
+        height: 100%;
+        padding: 0 1em;
+        overflow: visible;
+
+        /* Margin bottom to accomodate shadow */
+        -webkit-box-sizing: border-box;
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        margin-bottom: 1em;
+    }
 }
 
 /* Inline code */
 :not(pre) > code {
-    padding: 0 0.2em;
-    box-shadow: 0px 0px 0px 1px #dfdfdf;
-}
-
-/* Margin bottom to accomodate shadow */
-:not(pre) > code[class*="language-"],
-code {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-    margin-bottom: 1em;
-}
-
-/* Inline code */
-:not(pre) > code[class*="language-"] {
     position: relative;
     padding: .2em;
     -webkit-border-radius: 0.3em;
@@ -98,7 +93,7 @@ code {
     transform: rotate(-2deg);
 }
 
-:not(pre) > code[class*="language-"]:after,
+:not(pre) > code:after,
 [class*="language-"]:after {
     right: 0.75em;
     left: auto;


### PR DESCRIPTION
- Fixes overflow on Firefox
- Fixes inline code blocks to match with Coy theme (red text, border, padding, etc)
- Fixes right border not appearing

**before**:

![coy-before](https://cloud.githubusercontent.com/assets/3130334/12470310/b18e7554-bfb8-11e5-8dcc-882c536e40bd.png)

**after**:

![coy-after](https://cloud.githubusercontent.com/assets/3130334/12470315/b54f9312-bfb8-11e5-8c88-74cb5ff1f61d.png)