### PR TITLE
Fix RemoteStorage support

### DIFF
--- a/app/scripts/apps/notes/show/controller.js
+++ b/app/scripts/apps/notes/show/controller.js
@@ -90,9 +90,13 @@ define([
 
             Radio.request('notes', 'get:model:full', this.options)
             .spread(function(note, notebook) {
-                self.view.options.notebook = notebook;
-                self.view.model.set(note.attributes);
-                self.view.model.trigger('synced');
+                Radio.request('markdown', 'render', note)
+                .then(function(content) {
+                    self.view.options.notebook = notebook;
+                    self.view.options.content = content;
+                    self.view.model.set(note.attributes);
+                    self.view.model.trigger('synced');
+                });
             })
             .fail(function(e) {
                 console.error('After sync error:', e);


### PR DESCRIPTION
Hi! I've seen that you've referenced a commit on my issue, so I've decided to give it a try and unfortunately, this wasn't still working. So I've decided to be brave and to contribute a bit.

There were two issues with the RemoteStorage module: on the local version, `model.updated` is actually undefined, triggering updates all the time. `model.attributes.updated` is the actual value to check, for the local model. To make it clear which is the local model vs which is the remote one, I've renamed them `lmodel` (resp. `rmodel`) for the local (resp. remote) model.

The second issue was that there was a missing check for remote-to-local sync (if the note has been remotely updated but not locally). I just got inspired from the Dropbox sync. Maybe it'd be worth it to make these checks abstract over the sync adapter used, in a future version? It's much more work, so I haven't done that yet :-P

There's also another separate commit which updates the content of a note in real-time. That is, if you're looking at a given note on machine A, and you change it on machine B, now the content will be updated on machine A as soon as the update is retrieved on this machine.

@wwebfor / @wwwredfish, can you have a look, please? Thank you!