### PR TITLE
Add tag location

### DIFF
--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -56,7 +56,7 @@
             <i class="icon-trashed"></i> {{i18n('Trash')}}
         </a>
         <a class="list-group-item sidemenu--item" href="#{{uri}}notebooks">
-            <i class="icon-notebook"></i> {{i18n('Notebooks')}}
+            <i class="icon-notebook"></i> {{i18n('Notebooks & Tags')}}
         </a>
         <a class="list-group-item sidemenu--item" href="#{{ uri }}notes/f/task">
             <i class="icon-ok"></i> {{ i18n('Open tasks') }}


### PR DESCRIPTION
Not clear in navbar where to find tags. Possibly should break tags into separate item later?