### PR TITLE
"Other" not any more hard coded into sidebar template

### DIFF
--- a/app/scripts/apps/settings/sidebar/template.html
+++ b/app/scripts/apps/settings/sidebar/template.html
@@ -25,7 +25,7 @@
             {{i18n('Modules')}}
         </a>
 
-        <li class="list-group-item list--settings -disabled">Other</li>
+        <li class="list-group-item list--settings -disabled">{{i18n('Other')}}</li>
         <a class="list-group-item list--settings" href="#{{uri}}settings/importExport">
             <i class="icon-cog"></i>
             {{i18n('Import & export')}}


### PR DESCRIPTION
Fixes #510

Instead of always loading "Other" in the sidebar of settings for every language, the translation for "Other" is looked up in the translation file.