### PR TITLE
Cancel doesn't save changes any more

### DIFF
--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -35,6 +35,11 @@ define([
         initialize: function(options) {
             this.options = options;
 
+            // Saves data before you change anything, in case you cancel editing
+            this.dataBeforeChange = null;
+            // Data should be deleted if user wants to cancel editing
+            this.deleteData = false;
+
             _.bindAll(this, 'show', 'redirect');
 
             // Fetch everything
@@ -102,6 +107,17 @@ define([
             // Listen to view events
             this.listenTo(this.view, 'save', this.save);
             this.listenTo(this.view, 'cancel', this.showConfirm);
+
+            // Get data before any change is made
+            // so that it can be reset when you cancel editing
+            var self = this;
+            this.getContent()
+            .then(function(data) {
+                self.dataBeforeChange = data;
+            })
+            .fail(function(e) {
+                console.error('Error getting data on start', e);
+            });
         },
 
         save: function() {
@@ -136,17 +152,14 @@ define([
 
             return this.getContent()
             .then(function(data) {
-                var model = self.view.model.pick('title', 'content', 'notebookId');
-                data      = _.pick(data, 'title', 'content', 'notebookId');
-
-                // To check if they are equal
-                model.content = _.unescape(model.content);
-                model.title   = _.unescape(model.title);
-
-                if (_.isEqual(model, data)) {
+                // Redirect if data wasn't changed
+                if (_.isEqual(self.dataBeforeChange, data)) {
                     return self.redirect();
                 }
 
+                // User perhaps wants to cancel editing,
+                // if not, deleteData will be set false again in onConfirmCancel
+                self.deleteData = true;
                 Radio.request('Confirm', 'start', $.t('You have unsaved changes.'));
             })
             .fail(function(e) {
@@ -154,16 +167,35 @@ define([
             });
         },
 
+        // Called when the cancel dialog was accepted
         redirect: function() {
             if (!this.view.getOption('redirect')) {
                 return;
             }
 
             // Stop the module and navigate back
+            if(this.deleteData){
+                this.deleteData = false; // TODO wichtig?
+                if(this.options.method === "add") {
+                    // Delete the note if editing of a new note was canceled
+                    var self = this;
+                    requirejs(['apps/notes/remove/controller'], function(Controller) {
+                        new Controller(_.extend({},
+                                {id: self.view.model.id, deleteDirect: true}));
+                    });
+                }
+                else if(this.options.method === "edit") {
+                    // Save the note without any change
+                    // if editing of an existing note was canceled
+                    Radio.request('notes', 'save', this.view.model, this.dataBeforeChange);
+                }
+            }
+
             Radio.trigger('notesForm', 'stop');
             Radio.request('uri', 'back');
         },
 
+        // Called when the cancel dialog was canceled
         onConfirmCancel: function() {
             // Rebind keybindings again because TW bootstrap modal overrites ESC.
             this.view.trigger('bind:keys');

--- a/app/scripts/apps/notes/remove/controller.js
+++ b/app/scripts/apps/notes/remove/controller.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (C) 2015 Laverna project Authors.
- * 
+ *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -39,8 +39,18 @@ define([
             this.listenTo(Radio.channel('Confirm'), 'confirm', this.remove);
 
             // Fetch the note by ID
+            var self = this;
             Radio.request('notes', 'get:model', options)
-            .then(this.showConfirm);
+            .then(function(model){
+                // Delete note without dialog when new note was canceled
+                if(self.options.deleteDirect){
+                    Radio.request('notes', 'remove',model);
+                }
+                // Or else show the dialog
+                else{
+                    self.showConfirm(model);
+                }
+            });
         },
 
         /**


### PR DESCRIPTION
Cancel Button in editing mode doesn't saves the changes any more. This bug happend due to the autosave feature, which automatically saves changes without asking. This bug was solved by saving the unchanged note in the variable "dataBeforeChange" before any change was made. When you now cancel editing, this data will override the autosaved note. When you cancel editing a new note, it will be deleted. If your computer crashes while editing, the autosaved note will still be there, so nothing is lost.