### PR TITLE
Fix a translation bug with "You have unsaved changes."

### DIFF
--- a/app/locales/ar/translation.json
+++ b/app/locales/ar/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "قائمة المساهمين",
     "List of all used libraries": "قائمة جميع المكتبات المستخدمة",
     "Are you sure?": "هل أنت متأكد؟",
-    "You have unsaved changes.": "لديك تغييرات لم تحفظها.",
+    "You have unsaved changes": "لديك تغييرات لم تحفظها.",
     "Dropbox API key": "مفتاح API لـ Dropbox",
     "Required": "مطلوب",
     "Optional": "اختياري",

--- a/app/locales/da/translation.json
+++ b/app/locales/da/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Liste over bidragsydere",
     "List of all used libraries": "Liste over alle benyttede libraries",
     "Are you sure?": "Er du nu helt sikker?",
-    "You have unsaved changes.": "Du har ikke-gemte ændringer.",
+    "You have unsaved changes": "Du har ikke-gemte ændringer.",
     "Dropbox API key": "Dropbox API nøgle",
     "Required": "Obligatorisk",
     "Optional": "Valgfrit",

--- a/app/locales/de/translation.json
+++ b/app/locales/de/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Liste der Mitwirkenden",
     "List of all used libraries": "Liste aller benutzten Bibliotheken",
     "Are you sure?": "Sind Sie sicher?",
-    "You have unsaved changes.": "Sie haben nicht gespeicherte Änderungen",
+    "You have unsaved changes": "Sie haben nicht gespeicherte Änderungen.",
     "Dropbox API key": "Dropbox API Schlüssel",
     "Required": "Erforderlich",
     "Optional": "Optional",

--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "List of contributors",
     "List of all used libraries": "List of all used libraries",
     "Are you sure?": "Are you sure?",
-    "You have unsaved changes.": "You have unsaved changes.",
+    "You have unsaved changes": "You have unsaved changes.",
     "Dropbox API key": "Dropbox API key",
     "Required": "Required",
     "Optional": "Optional",

--- a/app/locales/fr/translation.json
+++ b/app/locales/fr/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Liste des contributeurs",
     "List of all used libraries": "Liste de toutes les librairies utilisées",
     "Are you sure?": "Eêts-vous sûr(e)",
-    "You have unsaved changes.": "Certaines modifications ne sont pas sauvegardées.",
+    "You have unsaved changes": "Certaines modifications ne sont pas sauvegardées.",
     "Dropbox API key": "Clé de l'API Dropbox",
     "Required": "Requis",
     "Optional": "Optionel",

--- a/app/locales/ko/translation.json
+++ b/app/locales/ko/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "기여자 목록",
     "List of all used libraries": "사용된 라이브러리 목록",
     "Are you sure?": "정말이세요?",
-    "You have unsaved changes.": "변경한 사항이 저장되지 않습니다.",
+    "You have unsaved changes": "변경한 사항이 저장되지 않습니다.",
     "Dropbox API key": "Dropbox API 키",
     "Required": "필수사항",
     "Optional": "선택사항",

--- a/app/locales/lt/translation.json
+++ b/app/locales/lt/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Prisidėjusių sąrašas",
     "List of all used libraries": "Naudotų bibliotekų sąrašas",
     "Are you sure?": "Esate tuo tikras?",
-    "You have unsaved changes.": "Turite neišsaugotų pakeitimų.",
+    "You have unsaved changes": "Turite neišsaugotų pakeitimų.",
     "Dropbox API key": "Dropbox API raktas",
     "Required": "Privaloma",
     "Optional": "Nebūtina",

--- a/app/locales/lv/translation.json
+++ b/app/locales/lv/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Līdzstrādnieku saraksts",
     "List of all used libraries": "Izmantoto koda bibliotēku saraksts",
     "Are you sure?": "Vai esat pārliecināts/-a?",
-    "You have unsaved changes.": "Jums ir nesaglabātas izmaiņas.",
+    "You have unsaved changes": "Jums ir nesaglabātas izmaiņas.",
     "Dropbox API key": "Dropbox API atslēga",
     "Required": "Obligāts",
     "Optional": "Neobligāts",

--- a/app/locales/sq/translation.json
+++ b/app/locales/sq/translation.json
@@ -80,7 +80,7 @@
     "List of contributors": "Listë kontribuesish",
     "List of all used libraries": "Listë e krejt librarive të përdorura",
     "Are you sure?": "Jeni i sigurt?",
-    "You have unsaved changes.": "Keni ndryshime të paruajtura.",
+    "You have unsaved changes": "Keni ndryshime të paruajtura.",
     "Dropbox API key": "Kyç API Dropbox-i",
     "Required": "E domosdoshme",
     "Optional": "Opsionale",

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -147,7 +147,7 @@ define([
                     return self.redirect();
                 }
 
-                Radio.request('Confirm', 'start', $.t('You have unsaved changes.'));
+                Radio.request('Confirm', 'start', $.t('You have unsaved changes'));
             })
             .fail(function(e) {
                 console.error('form ShowConfirm', e);

--- a/app/scripts/apps/settings/controller.js
+++ b/app/scripts/apps/settings/controller.js
@@ -156,7 +156,7 @@ define([
             }
 
             Radio.request('Confirm', 'start', {
-                content   : $.t('You have unsaved changes.'),
+                content   : $.t('You have unsaved changes'),
                 onconfirm : onconfirm,
                 onreject  : onreject
             });


### PR DESCRIPTION
The "You have unsaved changes." sentence in the cancel dialog was never translated. This was due to the dot in the sentence in the translation files. In JSON files, this dot is a call for a subclass, not the end of a sentence. Because of that, the translation was never found. I deleted the dot in the files where a new cancel dialog is created and in all translation files.