### PR TITLE
Translate profile name in Settings->Profile

### DIFF
--- a/app/locales/de/translation.json
+++ b/app/locales/de/translation.json
@@ -132,6 +132,7 @@
         }
     },
     "profile": {
+		"profile name": "Profilname",
         "confirm remove": "Das Profil **__profile__** wird mit allen Daten inklusive Notizen, Tags und Notizbüchern gelöscht. Dieser Vorgang kann nicht rückgängig gemacht werden!",
         "type name": "Profilnamen eingeben"
     },

--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -134,6 +134,7 @@
         }
     },
     "profile": {
+		"profile name": "Profile name",
         "confirm remove": "Profile **__profile__** will be removed with all the data, including notes, tags, and notebooks. This action is irreversible!",
         "type name": "Type profile name"
     },

--- a/app/locales/ru/translation.json
+++ b/app/locales/ru/translation.json
@@ -92,9 +92,11 @@
     "Profiles": "Профили",
     "Import settings": "Импортировать настройки",
     "Export settings": "Экспортировать настройки",
-    "Profile name": "Имя профиля",
     "Action": "Действие",
     "Trashed": "Корзина",
     "New notebook": "Новый блокнот",
-    "Are you sure? You have unsaved changes": "Вы уверены? У вас есть несохраненные изменения"
+    "Are you sure? You have unsaved changes": "Вы уверены? У вас есть несохраненные изменения",
+	"profile": {
+		"profile name": "Имя профиля"
+	}
 }

--- a/app/locales/tr/translation.json
+++ b/app/locales/tr/translation.json
@@ -92,7 +92,6 @@
     "Profiles": "Profiller",
     "Import settings": "Ayarları içeri aktar",
     "Export settings": "Ayarları dışarı aktar",
-    "Profile name": "Profil adı",
     "Action": "Eylem",
     "Remove profile": "'__profile__' profilini silmek istediğinden emin misin?",
     "Change shortcuts": "Kısayol ayarlarını değiştir",
@@ -102,6 +101,9 @@
     "Credits": "Katkılar",
     "List of contributors": "Katkıda bulunanlar",
     "List of all used libraries": "Kullanılan kütüphaneler",
+	"profile": {
+    	"profile name": "Profil adı"
+	},
     "notebooks": {
         "name": "Not defteri adı verin"
     },

--- a/app/scripts/apps/settings/show/templates/profiles.html
+++ b/app/scripts/apps/settings/show/templates/profiles.html
@@ -1,7 +1,7 @@
 <table class="table table-hover">
     <thead>
         <tr>
-            <th>{{ i18n('Profile name') }}</th>
+            <th>{{ i18n('profile.profile name') }}</th>
             <th width="5%">{{ i18n('Action') }}</th>
         </tr>
     </thead>


### PR DESCRIPTION
Now the "profile name" string will be translated. Although the i18n mark
was set in the profiles.html, the "Profile name" was missing in the
translation files. So I changed the i18n call to 'profile.profile name',
updated the translation in the Russian and Turkish translation and added
the translation to the English and German file.