### PR TITLE
Allow Unicode in tags

### DIFF
--- a/app/scripts/modules/markdown/libs/markdown-it.js
+++ b/app/scripts/modules/markdown/libs/markdown-it.js
@@ -59,7 +59,10 @@ define([
                     return '<div class="math block">$$' + tokens + '$$</div>';
                 },
             })
-            .use(hash)
+            .use(hash, {
+				hashtagRegExp: '[\\u0021-\\uFFFF\\w\\-]+|<3',
+				preceding: '^|\\s'
+				})
             .use(task.init)
             .use(file.init)
             ;


### PR DESCRIPTION
Fixes #491

You can now use Unicode characters in tags. I used a code snippet that
the creator of the markdown-it-hashtag created exactly for this problem
( https://github.com/svbergerem/markdown-it-hashtag/blob/master/test/hashtag.js#L23-L27 ). I modified it to use \u (four hexadecimal digits) instead of \x (two hexadecimal digits), so that you can use all of the Unicode symbols.