### PR TITLE
Add missing dependency to dev-ip

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chai": "^3.5.0",
     "cordova-lib": "^6.2.0",
     "del": "^2.2.1",
+    "dev-ip": "^1.0.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-clean-css": "^2.0.10",


### PR DESCRIPTION
The package.json was missing a dependency to the `dev-ip` module, which caused the `gulp build` command to fail. This commit fixes that issue.