### PR TITLE
Fix point in "unsaved data" dialog again

### DIFF
--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -160,7 +160,7 @@ define([
                 // User perhaps wants to cancel editing,
                 // if not, deleteData will be set false again in onConfirmCancel
                 self.deleteData = true;
-                Radio.request('Confirm', 'start', $.t('You have unsaved changes.'));
+                Radio.request('Confirm', 'start', $.t('You have unsaved changes'));
             })
             .fail(function(e) {
                 console.error('form ShowConfirm', e);


### PR DESCRIPTION
I fixed this bug before( #532 ), but somehow another commit overwrote the
deletion of the point in the notes form controller. I commit this one
little change again.