### PR TITLE
Don't save "wrong" tags anymore

### DIFF
--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -125,7 +125,7 @@ define([
 
             return this.getContent()
             .then(function(data) {
-                return Radio.request('notes', 'save', self.view.model, data);
+                return Radio.request('notes', 'save', self.view.model, data, self.view.options.saveTags);
             })
             .fail(function(e) {
                 console.error('Error', e);

--- a/app/scripts/apps/notes/form/views/formView.js
+++ b/app/scripts/apps/notes/form/views/formView.js
@@ -156,6 +156,10 @@ define([
                 return;
             }
 
+			// Don't save tags when auto save notes
+			// so that no unfinished tags are saved
+			this.options.saveTags = false;
+
             this.options.redirect = false;
             console.log('Auto saving the note...');
             this.trigger('save');
@@ -166,6 +170,7 @@ define([
                 e.preventDefault();
             }
 
+			this.options.saveTags = true;
             this.options.isClosed = true;
             this.options.redirect = true;
             this.trigger('save');

--- a/app/scripts/collections/modules/notes.js
+++ b/app/scripts/collections/modules/notes.js
@@ -42,16 +42,25 @@ define([
          * @type object Backbone model
          * @type object new values
          */
-        saveModel: function(model, data) {
+        saveModel: function(model, data, saveTags) {
+			if(saveTags == null){
+				saveTags = true;
+			}
             var saveFunc = _.bind(ModuleObject.prototype.saveModel, this);
 
-            // Before saving the model, add tags
-            return new Q(Radio.request('tags', 'add', data.tags || [], {
-                profile: model.profileId
-            }))
-            .then(function() {
-                return saveFunc(model, data);
-            });
+			if(saveTags){
+            	// Before saving the model, add tags
+				return new Q(Radio.request('tags', 'add', data.tags || [], {
+					profile: model.profileId
+				}))
+				.then(function() {
+					return saveFunc(model, data);
+				});
+			}
+
+			// Save model without tags
+			return saveFunc(model,data);
+
         },
 
         /**


### PR DESCRIPTION
Fixes #493

"Wrong" means saved tags due to the auto save feature which saved the tags,
even if you were not finished writing them or deleted them afterwards. I fixed this by
creating the flag "saveTags", which is false when the note is auto saved
and true when it's really saved. So now tags are only saved when you
save the note on your own.

Thanks to @wwebfor for giving me a new way of seeing this problem and
thus making it much easier to solve for me.