### PR TITLE
Close the settings when save is pressed

### DIFF
--- a/app/scripts/apps/settings/controller.js
+++ b/app/scripts/apps/settings/controller.js
@@ -124,6 +124,7 @@ define([
 
             // Do nothing if there are not any changes
             if (_.isEmpty(this.changes)) {
+				this.confirmRedirect();
                 return;
             }
 
@@ -132,6 +133,7 @@ define([
 
             this.saves = _.union(this.saves, this.changes);
             this.changes = {};
+			this.confirmRedirect();
         },
 
         /**


### PR DESCRIPTION
When you press the save button in the settings you will now be automatically
redirected to the last page you visited. I implemented this, because it is also
like this when you edit a note. I think this should be common
practice among all the save buttons.