### PR TITLE
Handle empty title

### DIFF
--- a/app/locales/de/translation.json
+++ b/app/locales/de/translation.json
@@ -104,6 +104,7 @@
     "Editor": "Editor",
     "Download": "Download",
     "Everything": "Alles",
+    "Untitled": "Unbenannt",
     "encryption": {
         "wait": "Bitte warten, bis die Verschlüsselung abgeschlossen ist",
         "error": "Verschüsselungsfehler",

--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -114,6 +114,7 @@
     "Everything": "Everything",
     "Enabled": "Enabled",
     "Disabled": "Disabled",
+    "Untitled": "Untitled",
     "encryption": {
         "provide password": "Please, provide your password",
         "change password": "Type your password here to change it",

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -111,7 +111,7 @@ define([
             return this.getContent()
             .then(function(data) {
                 if (data.title === '') {
-                    var title = i18n.t('New Note');
+                    var title = i18n.t('Untitled');
                     data.title = title;
                     Radio.request('global', 'set:title', title);
                 }

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -12,9 +12,10 @@ define([
     'jquery',
     'backbone.radio',
     'marionette',
+    'i18next',
     'apps/notes/form/views/formView',
     'apps/notes/form/views/notebooks'
-], function (_, Q, $, Radio, Marionette, View, NotebooksView) {
+], function (_, Q, $, Radio, Marionette, i18n, View, NotebooksView) {
     'use strict';
 
     /**
@@ -110,7 +111,7 @@ define([
             return this.getContent()
             .then(function(data) {
                 if (data.title === '') {
-                    var title = 'New-Note-' + new Date().toLocaleDateString();
+                    var title = i18n.t('New Note');
                     data.title = title;
                     Radio.request('global', 'set:title', title);
                 }

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -109,6 +109,11 @@ define([
 
             return this.getContent()
             .then(function(data) {
+                if (data.title === '') {
+                    var title = 'New-Note-' + new Date().toLocaleDateString();
+                    data.title = title;
+                    Radio.request('global', 'set:title', title);
+                }
                 return Radio.request('notes', 'save', self.view.model, data);
             })
             .fail(function(e) {


### PR DESCRIPTION
When saving a note, check if the title is empty and, if yes, give it a default name ('New Note').

Fixes #540 