### PR TITLE
Add translation to drop file dialog + cleanup

### DIFF
--- a/app/locales/de/translation.json
+++ b/app/locales/de/translation.json
@@ -114,6 +114,7 @@
     "Disabled": "Deaktiviert",
     "Untitled": "Unbenannt",
     "Line of": "Zeile {{currentLine}} von {{numberOfLines}}",
+	"Drop files": "Ziehen Sie hier die Dateien zum Hochladen hinein",
     "encryption": {
         "provide password": "Bitte, geben Sie Ihr Passwort ein",
         "change password": "Geben Sie Ihr Passwort hier ein, um es zu ändern",

--- a/app/locales/en/translation.json
+++ b/app/locales/en/translation.json
@@ -116,6 +116,7 @@
     "Disabled": "Disabled",
     "Untitled": "Untitled",
     "Line of": "Line {{currentLine}} of {{numberOfLines}}",
+	"Drop files": "Drop files here to upload",
     "encryption": {
         "provide password": "Please, provide your password",
         "change password": "Type your password here to change it",

--- a/app/scripts/apps/notes/form/controller.js
+++ b/app/scripts/apps/notes/form/controller.js
@@ -182,7 +182,7 @@ define([
 
             // Stop the module and navigate back
             if(this.deleteData){
-                this.deleteData = false; // TODO wichtig?
+                this.deleteData = false;
                 if (this.options.method === 'add') {
                     // Delete the note if editing of a new note was canceled
                     var self = this;

--- a/app/scripts/modules/fileDialog/views/dialog.js
+++ b/app/scripts/modules/fileDialog/views/dialog.js
@@ -8,13 +8,14 @@
 /* global define, Modernizr */
 define([
     'underscore',
+	'i18next',
     'marionette',
     'backbone.radio',
     'behaviors/modalForm',
     'dropzone',
     'text!modules/fileDialog/templates/dialog.html',
     'text!modules/fileDialog/templates/dropzone.html'
-], function(_, Marionette, Radio, ModalForm, Dropzone, Tmpl, dropzoneTmpl) {
+], function(_, i18n, Marionette, Radio, ModalForm, Dropzone, Tmpl, dropzoneTmpl) {
     'use strict';
 
     /**
@@ -67,7 +68,8 @@ define([
                     accept          : _.bind(this.getImage, this),
                     thumbnailWidth  : 100,
                     thumbnailHeight : 100,
-                    previewTemplate: dropzoneTmpl
+                    previewTemplate: dropzoneTmpl,
+					dictDefaultMessage: i18n.t('Drop files')
                 });
             }
         },


### PR DESCRIPTION
Make the "Drop files here to upload" translatable and add a German and
English translation. Also delete a TODO Comment from an older commit.