### PR TITLE
Add shortcut to indent lines in editor

### DIFF
--- a/app/scripts/modules/codemirror/controller.js
+++ b/app/scripts/modules/codemirror/controller.js
@@ -106,6 +106,7 @@ define([
                 lineNumbers   : false,
                 matchBrackets : true,
                 lineWrapping  : true,
+				indentUnit	  : 4,
                 extraKeys     : {
                     'Cmd-B'  : this.boldAction,
                     'Ctrl-B' : this.boldAction,
@@ -136,7 +137,14 @@ define([
                     'Cmd-D'  : this.hrAction,
                     'Ctrl-D' : this.hrAction,
 
-                    'Enter': 'newlineAndIndentContinueMarkdownList'
+					// Ctrl+. - indent line
+					'Ctrl-.' 		: 'indentMore',
+					'Shift-Ctrl-.' 	: 'indentLess',
+					'Cmd-.' 		: 'indentMore',
+					'Shift-Cmd-.'	: 'indentLess',
+
+                    'Enter' : 'newlineAndIndentContinueMarkdownList',
+
                 }
             });
 


### PR DESCRIPTION
Added a shortcut to indent a line or block in the editor. Also change
the indentUnit to 4, so that one indent will change the level of indent in
lists.