### PR TITLE
Change indentUnit from 4 to 3

### DIFF
--- a/app/scripts/modules/codemirror/controller.js
+++ b/app/scripts/modules/codemirror/controller.js
@@ -106,7 +106,7 @@ define([
                 lineNumbers   : false,
                 matchBrackets : true,
                 lineWrapping  : true,
-				indentUnit	  : 4,
+                indentUnit    : 3,
                 extraKeys     : {
                     'Cmd-B'  : this.boldAction,
                     'Ctrl-B' : this.boldAction,
@@ -137,11 +137,11 @@ define([
                     'Cmd-D'  : this.hrAction,
                     'Ctrl-D' : this.hrAction,
 
-					// Ctrl+. - indent line
-					'Ctrl-.' 		: 'indentMore',
-					'Shift-Ctrl-.' 	: 'indentLess',
-					'Cmd-.' 		: 'indentMore',
-					'Shift-Cmd-.'	: 'indentLess',
+                    // Ctrl+. - indent line
+                    'Ctrl-.'        : 'indentMore',
+                    'Shift-Ctrl-.'  : 'indentLess',
+                    'Cmd-.'         : 'indentMore',
+                    'Shift-Cmd-.'   : 'indentLess',
 
                     'Enter' : 'newlineAndIndentContinueMarkdownList',
 


### PR DESCRIPTION
3 is the smallest indent unit that will cause a
nested ordered list to be indented properly.

Shrink it to save horizontal space on smaller screens.