### PR TITLE
NavBar: Changes in Header and NavBar Content

### DIFF
--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -10,6 +10,7 @@
                 </span>
             </a>
         </li>
+
         <li class="header--col--left--search">
             <button id="header--sbtn" class="btn navbar-btn header--sbtn" title="{{i18n('Search')}}">
                 <i class="icon-search"></i>
@@ -17,10 +18,12 @@
         </li>
     </ul>
 
+
     <form id="header--search" class="header--search" role="search">
         <input id="header--search--input" class="header--search--input form-control"
             type="text" placeholder="{{i18n('Search')}}" value="{{args.query}}" />
     </form>
+
 
     <div class="navbar-right header--right navbar-btn">
         <% if (isSyncEnabled()) { %>

--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -40,11 +40,13 @@
     <div class="list-group">
         <div class="list-group-item sidemenu--item -disabled sidemenu--close">
             <i class="icon-left-open-big"></i>
-            {{i18n('Close')}}
+            {{i18n('Menu')}}
             <button type="button" class="close" aria-hidden="true">
                 &times;
             </button>
         </div>
+
+        <div class="list-group-item sidemenu--item -disabled">{{i18n('General')}}</div>
 
         <a class="list-group-item sidemenu--item" href="#{{uri}}notes">
             <i class="icon-note"></i> {{i18n('All Notes')}}

--- a/app/styles/core/header.less
+++ b/app/styles/core/header.less
@@ -42,6 +42,7 @@
     background-color: transparent;
 }
 
+
 /**
  * Search form
  */
@@ -49,6 +50,13 @@
     &:extend(.navbar-form);
     display : none;
     width   : 100%;
+    position: absolute;
+    right: 0px;
+    left: auto;
+    padding-left: 160px;
+    padding-top: 45px;
+
+
 }
 .header--search--input {
 }
@@ -60,7 +68,7 @@
 .header.-search {
     .navbar-right,
     .navbar-left {
-        display: none;
+        position: relative;
     }
 
     .header--search {


### PR DESCRIPTION
**Changes**

- Created "General" label for categorizing the first five options in side bar.
-  Renamed header title from "Close" to "Menu"
-  Removed the hover  effect as well as button action event when clicking on a header title in the Navigation Bar. (It remains in the "menu icon") 

(1) I felt that adding another label kept everything consistent. "General" was the only name I could think of that best fits with each option but if someone else wants to suggest or change it, I'm all ears. 

(2 - 3)  With this change and the last one, I didn't like the feature of having the title and the icon next to it as a single button (I do think it would fit the mobile version due to the touch screen). Right now, I've only removed the button functionality of the Menu icon and the header title from the Navigation Bar (so only the menu icon opens up the side bar), but in a future Pull Request, I plan on doing the same with the "<" icon and its header title, in the sidebar. I've also renamed the title from "Close" to "Menu" as I'm going to be implementing a tooltip feature soon for some of these buttons which will make having a "Close" button irrelevant.  

The biggest problem I had with implementing this change was formatting the Navigation Bar's header title so that it would remain on the same level as the menu and search icons. I ended up having to use a combination of the **padding-top** and **display** elements to get it to stay properly (I don't have much experience with CSS so if anyone knows of a better way to achieve this, let me know).