### PR TITLE
Electron: Add electron-context-menu 0.6.0

### DIFF
--- a/electron.js
+++ b/electron.js
@@ -7,8 +7,9 @@ const electron        = require('electron'),
 
 const {app, BrowserWindow, Menu, Tray, protocol} = electron;
 
-let argv = require('minimist')(process.argv.slice(1)),
-    win  = null,
+let argv        = require('minimist')(process.argv.slice(1)),
+    contextMenu = require('electron-context-menu')({}),
+    win         = null,
     appHelper;
 
 // Show command line help

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "electron.js",
   "dependencies": {
     "chokidar": "^1.6.0",
+    "electron-context-menu": "^0.6.0",
     "electron-window-state": "^3.0.3",
     "finalhandler": "^0.5.0",
     "glob": "^7.0.5",


### PR DESCRIPTION
https://github.com/sindresorhus/electron-context-menu

Otherwise the Electron app does nothing on right-click. This context menu plugin is convenient for right-clicking and copying links. It can also be customized in the future with additional menu items.

I tested that it doesn't do anything in the regular browser, only in Electron.