### PR TITLE
Navbar show tree

### DIFF
--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -69,11 +69,52 @@
 
         <% if (notebooks !== null && notebooks.length) { %>
         <div class="list-group-item sidemenu--item -disabled">{{i18n('Notebooks')}}</div>
-        <% notebooks.forEach(function(notebook) { %>
-        <a class="list-group-item sidemenu--item" href="#{{uri}}notes/f/notebook/q/{{notebook.id}}">
+        <%
+        // Draw the tree
+        lastId = "0";
+        parentStack = [];
+        level = 0;
+        lastIndentOffset = -0.15; // End pipe has less indent
+        indentOffset = 0.3;
+        indentScale = 2.3; // multipler for level in em
+        indentInEm = function(level, lastIndent) {
+            return (level - 1) * indentScale + indentOffset + (lastIndent ? lastIndentOffset : 0);
+        };
+        notebooks.forEach(function(notebook, index) {
+            extraClass = (notebook.parentId !== "0")? "list-child-item" : ""; %>
+        <a class="list-group-item {{extraClass}} sidemenu--item"
+            href="#{{uri}}notes/f/notebook/q/{{notebook.id}}">
+            <% if (notebook.parentId !== "0") {
+                if (lastId === notebook.parentId) {
+                    level++;
+                    if (parentStack.length === 0 ||
+                        parentStack[parentStack.length - 1] !== notebook.parentId) {
+                        parentStack.push(lastId);
+                    }
+                } else {
+                    // Pop off the stack until we find the parent
+                    while (level > 0 && parentStack.length &&
+                        parentStack[parentStack.length - 1] !== notebook.parentId) {
+                        parentStack.pop();
+                        level--;
+                    }
+                }
+                lastChild = index == notebooks.length - 1;
+                if (level > 0) { %>
+                <span class="label-branch-indent" style="width:{{indentInEm(level,lastChild)}}em;" ></span>
+                <% }
+                if (lastChild) { %>
+                <span class="label-branch-last">----</span>
+                <% } else { %>
+                <span class="label-branch">----</span>
+                <% }
+            } else {
+                level = 0;
+            } %>
             <i class="icon-notebook"></i>  {=cleanXSS(notebook.name)}
         </a>
-        <% }); } %>
+        <% lastId = notebook.id;
+        }); } %>
 
         <div class="list-group-item sidemenu--item -disabled">{{i18n('Profiles')}}</div>
         <a class="list-group-item sidemenu--item<% if (profile === 'notes-db' || !profile) { %> active<% } %>" href="#/notes">

--- a/app/scripts/apps/navbar/show/template.html
+++ b/app/scripts/apps/navbar/show/template.html
@@ -69,52 +69,31 @@
 
         <% if (notebooks !== null && notebooks.length) { %>
         <div class="list-group-item sidemenu--item -disabled">{{i18n('Notebooks')}}</div>
-        <%
-        // Draw the tree
-        lastId = "0";
-        parentStack = [];
-        level = 0;
-        lastIndentOffset = -0.15; // End pipe has less indent
-        indentOffset = 0.3;
-        indentScale = 2.3; // multipler for level in em
-        indentInEm = function(level, lastIndent) {
-            return (level - 1) * indentScale + indentOffset + (lastIndent ? lastIndentOffset : 0);
-        };
-        notebooks.forEach(function(notebook, index) {
-            extraClass = (notebook.parentId !== "0")? "list-child-item" : ""; %>
+        <% // Draw the tree
+        for (var i = 0; i < notebooks.length; i++) {
+        var notebook = notebooks[i],
+            childLevel = getChildLevel(notebook.parentId),
+            lastChild = false,
+            lastNotebook = i == notebooks.length - 1;
+        if (childLevel > 0 && (lastNotebook ||
+            notebook.parentId !== notebooks[i + 1].parentId)) {
+            lastChild = true;
+        }
+        var extraClass = (childLevel > 0)? "list-child-item" : "";
+        %>
         <a class="list-group-item {{extraClass}} sidemenu--item"
             href="#{{uri}}notes/f/notebook/q/{{notebook.id}}">
-            <% if (notebook.parentId !== "0") {
-                if (lastId === notebook.parentId) {
-                    level++;
-                    if (parentStack.length === 0 ||
-                        parentStack[parentStack.length - 1] !== notebook.parentId) {
-                        parentStack.push(lastId);
-                    }
-                } else {
-                    // Pop off the stack until we find the parent
-                    while (level > 0 && parentStack.length &&
-                        parentStack[parentStack.length - 1] !== notebook.parentId) {
-                        parentStack.pop();
-                        level--;
-                    }
-                }
-                lastChild = index == notebooks.length - 1;
-                if (level > 0) { %>
-                <span class="label-branch-indent" style="width:{{indentInEm(level,lastChild)}}em;" ></span>
-                <% }
-                if (lastChild) { %>
-                <span class="label-branch-last">----</span>
-                <% } else { %>
-                <span class="label-branch">----</span>
-                <% }
-            } else {
-                level = 0;
-            } %>
+            <% if (childLevel > 0) { 
+            var indentInEm = getChildIndentEm(childLevel, lastChild);
+            %>
+            <span class="label-branch-indent" style="width:{{indentInEm}}em;" ></span>
+            <% lastStr = (lastChild)? "-last" : "";
+            %>
+            <span class="label-branch{{lastStr}}">----</span>
+            <% } %>
             <i class="icon-notebook"></i>  {=cleanXSS(notebook.name)}
         </a>
-        <% lastId = notebook.id;
-        }); } %>
+        <% } } %>
 
         <div class="list-group-item sidemenu--item -disabled">{{i18n('Profiles')}}</div>
         <a class="list-group-item sidemenu--item<% if (profile === 'notes-db' || !profile) { %> active<% } %>" href="#/notes">

--- a/app/scripts/apps/navbar/show/view.js
+++ b/app/scripts/apps/navbar/show/view.js
@@ -182,16 +182,32 @@ define([
 
                 profileLink: function(profileName) {
                     return Radio.request('uri', 'link:profile', '/notes', profileName);
-                }
+                },
 
-                /*
-                getChildLevel: function(notebook) {
-                    notebooks = this.options.notebooks;
-                    if (notebook.parentId !== "0") {
-                        return 1;
+                getChildLevel: function(parentId) {
+                    var level = 0,
+                        findParent = function(n) {
+                        if (parentId === n.id) {
+                            parentId = n.parentId;
+                            level++;
+                            return true;
+                        }
+                        return false;
+                    };
+                    while (parentId !== '0') {
+                        // Search for the parent
+                        this.notebooks.some(findParent);
                     }
-                    return 0;
-                } */
+                    return level;
+                },
+
+                getChildIndentEm: function(level, lastChild) {
+                    var lastIndentOffset = -0.15, // End pipe has less indent
+                        indentOffset = 0.3,
+                        indentScale = 2.3; // multipler for level in em
+                    return (level - 1) * indentScale + indentOffset +
+                        (lastChild ? lastIndentOffset : 0);
+                }
             };
         }
     });

--- a/app/scripts/apps/navbar/show/view.js
+++ b/app/scripts/apps/navbar/show/view.js
@@ -183,6 +183,15 @@ define([
                 profileLink: function(profileName) {
                     return Radio.request('uri', 'link:profile', '/notes', profileName);
                 }
+
+                /*
+                getChildLevel: function(notebook) {
+                    notebooks = this.options.notebooks;
+                    if (notebook.parentId !== "0") {
+                        return 1;
+                    }
+                    return 0;
+                } */
             };
         }
     });

--- a/app/styles/theme-default/sidemenu.less
+++ b/app/styles/theme-default/sidemenu.less
@@ -31,6 +31,34 @@
     font-size  : 1.3em;
 }
 
+.sidemenu--item.list-child-item {
+    padding-top : 0px;
+    padding-bottom : 0px;
+    min-height  : 0px;
+}
+
+.label-branch {
+    letter-spacing: -0.11em;
+}
+.label-branch-last {
+    .label-branch;
+}
+
+/* Center right pipe symbol (verticle box middle right) */
+.label-branch:before {
+    content: "\251C";
+}
+
+/* Bottom right pipe symbol (verticle box right) */
+.label-branch-last:before {
+    content: "\2514";
+}
+
+.label-branch-indent {
+    display: inline-block;
+}
+
+
 .sidemenu--close {
     cursor: pointer;
 }


### PR DESCRIPTION
In response to issue #402  I've added drawing a tree to the navbar to show notebooks in a hierarchy.  The tree works up to any depth, and it always shows a corner pipe for the last child. However, there's no logic to wrap the tree if it gets too long, but this case is unlikely.  The other assumption I made is that the list of notebooks is ordered with children after their parents.  

It seems to work well.  Tree branch icons might look better than the pipe symbols and dashes that I'm using.  Here's a screenshot:

![screen shot 2016-10-15 at 11 24 14 pm](https://cloud.githubusercontent.com/assets/764216/19415790/97ca1d52-9330-11e6-9cf5-717c3f5a3677.png)

The first commit was a messy proof of concept and a lot of the logic was moved out of the template in the second commit.  Let me know if I should squash these and resubmit.
