### PR TITLE
Improved line styles.

### DIFF
--- a/app/styles/theme-default/sidemenu.less
+++ b/app/styles/theme-default/sidemenu.less
@@ -47,11 +47,17 @@
 /* Center right pipe symbol (verticle box middle right) */
 .label-branch:before {
     content: "\251C";
+    /* line up with dashes */
+    font-size: 10pt;
 }
 
 /* Bottom right pipe symbol (verticle box right) */
 .label-branch-last:before {
     content: "\2514";
+    /* line up with dashes */
+    font-size: 10pt;
+    position: relative;
+    top: 0.04em;
 }
 
 .label-branch-indent {


### PR DESCRIPTION
This is the best I'm willing to do right now. I couldn't manage to shrink the line height of the center pipes to actually connect them.  Maybe you can take a crack at it?  At least the dashes are centered with the pipe now.

I think we will need icons to make this work well on mobile.  I have not tested this on android (I'll do that when I figure out how to build the APK), but I would bet it doesn't look pretty.

![screen shot 2016-10-20 at 5 59 50 pm](https://cloud.githubusercontent.com/assets/764216/19583198/812f6e40-96ef-11e6-99a0-36fff0db04a1.png)
