### PR TITLE
Remove bower step from installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ before_install:
     - npm install -g gulp bower jshint
 install:
     - npm install
-    - bower install
-    - cd test && bower install && cd ../
 script:
     - gulp build
     - gulp --root dist &

--- a/README.md
+++ b/README.md
@@ -79,11 +79,9 @@ cd laverna
 
 #### 3. Ensure you have the node.js platform installed. See OS-specific instructions on their [website][8].
 
-#### 4. Ensure you have the bower and gulp packages installed (locally and globally):
+#### 4. Ensure you have gulp package installed (locally and globally):
 
 ```bash
-$ npm install bower
-$ npm install -g bower
 $ npm install gulp
 $ npm install -g gulp
 ```
@@ -92,10 +90,6 @@ $ npm install -g gulp
 
 ```bash
 $ npm install
-$ bower install
-$ cd test
-$ bower install
-$ cd ..
 ```
 
 #### 6. Build minified version of Laverna:

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node ./server.js",
+    "prepublish": "bower install && cd test &&  bower install",
     "electron": "NODE_ENV=dev electron .",
     "karma": "./node_modules/.bin/karma start",
     "test:karma": "./node_modules/.bin/karma start --single-run"
@@ -24,6 +25,7 @@
     "serve-static": "^1.11.1"
   },
   "devDependencies": {
+    "bower": "^1.8.0",
     "browser-sync": "^2.14.0",
     "chai": "^3.5.0",
     "cordova-lib": "^6.3.0",


### PR DESCRIPTION
1. Added bower to devDependencies, so it would be installed via `npm install`
2. Created `prepublish` script (will be executed on `npm install`), that contain installation of bower components for app and test both
3. Removed `bower install` step from travis, `npm install` do the trick already
4. Remove `bower install` step from README

Improvements:
1. Less to type for fresh installation
2. No need to install bower globally