### PR TITLE
Edit Arch Linux section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The package can be found [here](https://aur.archlinux.org/packages/laverna/).
 For installation please use :
 
 ```bash
-$ yaourt -S laverna
+$ pacaur -S laverna
 ```
 
 For issue about installation please report [here](https://github.com/funilrys/PKGBUILD/issues/new) or contact [@funilrys](https://github.com/funilrys) on gitter [here](https://gitter.im/funilrys_/PKGBUILD)


### PR DESCRIPTION
It's time to move from `yaourt` to `pacaur` because `yaourt` don't have a clean build process.