### PR TITLE
Change divider hotkey to not conflict with "delete"

### DIFF
--- a/app/scripts/modules/codemirror/controller.js
+++ b/app/scripts/modules/codemirror/controller.js
@@ -136,6 +136,10 @@ define([
                     // Ctrl+G - attach file
                     'Cmd-G'  : this.attachmentAction,
                     'Ctrl-G' : this.attachmentAction,
+                    
+                    // Shift+Ctrl+- - divider
+                    'Shift-Cmd--'   : this.hrAction,
+                    'Shift-Ctrl--'  : this.hrAction,
 
 					// Ctrl+. - indent line
 					'Ctrl-.' 		: 'indentMore',

--- a/app/scripts/modules/codemirror/controller.js
+++ b/app/scripts/modules/codemirror/controller.js
@@ -133,13 +133,9 @@ define([
                     'Cmd-U'  : this.listAction,
                     'Ctrl-U' : this.listAction,
 
-                    // Ctrl+d - divider
+                    // Ctrl+G - attach file
                     'Cmd-G'  : this.attachmentAction,
                     'Ctrl-G' : this.attachmentAction,
-
-                    // Ctrl+d - divider
-                    'Cmd-D'  : this.hrAction,
-                    'Ctrl-D' : this.hrAction,
 
 					// Ctrl+. - indent line
 					'Ctrl-.' 		: 'indentMore',


### PR DESCRIPTION
Ctrl-d conflicts with default browser behavior of "delete forward character".