### PR TITLE
Reusable Vagrant Box for Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# Vagrant
+/.vagrant
+/.ansible-roles

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
+# vi: set ft=ruby :
+
+require 'shellwords'
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "bento/centos-7.3"
+  config.vm.hostname = "devel"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", type: "dhcp"
+
+  # Tweak the VMs configuration.
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 1024
+    vb.linked_clone = true
+  end
+
+  # Configure the VM using Ansible
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.galaxy_role_file = "requirements.yml"
+    ansible.galaxy_roles_path = ".ansible-roles"
+    ansible.provisioning_path = "/vagrant"
+    ansible.playbook = "vagrant.yml"
+    # allow passing ansible args from environment variable
+    ansible.raw_arguments = Shellwords::shellwords(ENV.fetch("ANSIBLE_ARGS", ""))
+  end
+end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+retry_files_enabled = false

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- name: vagrant-base
+  src: naftulikay.vagrant-base

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -1,0 +1,58 @@
+---
+- hosts: all
+  become: true
+  vars:
+    node_version: "6.11.0"
+  roles: [vagrant-base]
+  tasks:
+    - name: check if node is installed
+      command: ls /usr/local/node-{{ node_version }}/bin
+      register: node_result
+      failed_when: false
+      changed_when: false
+
+    - name: set node facts
+      set_fact:
+        node_installed: "{{ node_result.rc == 0 | bool }}"
+        node_shared_dir: /usr/local/node
+        node_install_dir: "/usr/local/node-{{ node_version }}"
+
+    - name: create node installation directory
+      file: path={{ node_install_dir }} state=directory mode=0755 owner=root group=root
+
+    - name: download node
+      unarchive:
+        src: https://nodejs.org/dist/v{{ node_version }}/node-v{{ node_version }}-linux-x64.tar.xz
+        remote_src: true
+        dest: "{{ node_install_dir}}"
+        extra_opts: ["--strip-components", "1"]
+      when: not node_installed
+
+    - name: create node installation symlink
+      file:
+        src: "{{ node_install_dir }}"
+        dest: "{{ node_shared_dir }}"
+        owner: root
+        group: root
+        state: link
+
+    - name: create node executable symlinks
+      file:
+        src: "{{ node_install_dir }}/bin/{{ item }}"
+        dest: "/usr/local/bin/{{ item }}"
+        owner: root
+        group: root
+        state: link
+      with_items:
+        - node
+        - npm
+
+    - name: create environment profile for node
+      copy:
+        content: |
+          #!/usr/bin/env bash
+          export PATH="$PATH:{{ node_shared_dir }}/bin"
+        dest: /etc/profile.d/99-node.sh
+        owner: root
+        group: root
+        mode: 0755


### PR DESCRIPTION
Because portability is king™.

#### WARNING

This is currently broken, due in part to some weird errors I get during building:

##### `npm install`

```
[vagrant@devel vagrant]$ npm install
laverna@0.7.4-RC1 /vagrant
└── (empty)

npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@^1.0.0 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.1.2: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm ERR! Linux 3.10.0-514.el7.x86_64
npm ERR! argv "/usr/local/node-6.11.0/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v6.11.0
npm ERR! npm  v3.10.10
npm ERR! path /vagrant/node_modules/npm/node_modules/node-gyp/node_modules/semver/bin/semver
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod '/vagrant/node_modules/npm/node_modules/node-gyp/node_modules/semver/bin/semver'
npm ERR! enoent ENOENT: no such file or directory, chmod '/vagrant/node_modules/npm/node_modules/node-gyp/node_modules/semver/bin/semver'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent

npm ERR! Please include the following file with any support request:
npm ERR!     /vagrant/npm-debug.log
npm ERR! code 1
```

##### `gulp install`

```
[vagrant@devel vagrant]$ gulp build
module.js:471
    throw err;
    ^

Error: Cannot find module 'cordova-lib'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/vagrant/gulps/mobile.js:3:45)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

Here is my `npm-debug.log`: [npm-debug.log.zip](https://github.com/Laverna/laverna/files/1116880/npm-debug.log.zip)

Not sure why it's not building. I would like to build the Electron app and package it for various Linux distributions.
