### PR TITLE
[FIX] Rename jade to pug

### DIFF
--- a/app/scripts/components/markdown/Markdown.js
+++ b/app/scripts/components/markdown/Markdown.js
@@ -17,7 +17,7 @@ import file from './file';
 
 // Import Prismjs components (http://prismjs.com/download.html?themes=prism&languages=)
 // eslint-disable-next-line
-const languages = `markup+css+clike+javascript+abap+actionscript+apacheconf+apl+applescript+aspnet+autoit+autohotkey+bash+basic+batch+c+brainfuck+bison+csharp+cpp+coffeescript+ruby+css-extras+d+dart+diff+docker+eiffel+elixir+erlang+fsharp+fortran+gherkin+git+glsl+go+groovy+handlebars+haskell+haxe+http+icon+inform7+ini+j+jade+java+julia+keyman+kotlin+latex+less+lolcode+lua+makefile+markdown+matlab+mel+mizar+monkey+nasm+nginx+nim+nix+nsis+objectivec+ocaml+oz+parigp+parser+pascal+perl+php+php-extras+powershell+processing+prolog+puppet+pure+python+q+qore+r+jsx+rest+rip+roboconf+crystal+rust+sas+sass+scss+scala+scheme+smalltalk+smarty+sql+stylus+swift+tcl+textile+twig+typescript+verilog+vhdl+vim+wiki+yaml`;
+const languages = `markup+css+clike+javascript+abap+actionscript+apacheconf+apl+applescript+aspnet+autoit+autohotkey+bash+basic+batch+c+brainfuck+bison+csharp+cpp+coffeescript+ruby+css-extras+d+dart+diff+docker+eiffel+elixir+erlang+fsharp+fortran+gherkin+git+glsl+go+groovy+handlebars+haskell+haxe+http+icon+inform7+ini+j+java+julia+keyman+kotlin+latex+less+lolcode+lua+makefile+markdown+matlab+mel+mizar+monkey+nasm+nginx+nim+nix+nsis+objectivec+ocaml+oz+parigp+parser+pascal+perl+php+php-extras+powershell+processing+prolog+pug+puppet+pure+python+q+qore+r+jsx+rest+rip+roboconf+crystal+rust+sas+sass+scss+scala+scheme+smalltalk+smarty+sql+stylus+swift+tcl+textile+twig+typescript+verilog+vhdl+vim+wiki+yaml`;
 _.each(languages.split('+'), lang => {
     require(`prismjs/components/prism-${lang}.min.js`);
 });


### PR DESCRIPTION
Hi, initially I cloned this repo because I wanted to fix a UI bug in the released version where the title for the note is not shown, and instead the word **title** is shown. Then I realized that this bug was already fixed in `dev` branch and `dev` branch is way ahead of master.

But I found another bug during the setup, that is caused by the renaming of `jade` into `pug` in the `prismjs` package since `1.8.2`: 
- https://github.com/PrismJS/prism/pull/1201
- https://github.com/PrismJS/prism/blob/gh-pages/CHANGELOG.md#182-2017-10-19

This bug causes the web app to throw error and stop working due to missing dependency:
```
Error: Cannot find module './prism-jade.min.js'.
```

Ideally the change should not affect this project because the version of the `prismjs` package is defined as `1.7.0` in `package-lock.json`, but somehow `1.7.0` in `package-lock.json` does not match `package.json` which is `"prismjs": "^1.8.1"`. So when I did `npm install`, it fetches `prismjs:1.8.4` and updates `package-lock.json`. Maybe you can regenerate the `package-lock.json` file? I've checked out `package-lock.json` in this PR.

FYI: npm's behavior regarding conflicting versions: 
- https://stackoverflow.com/a/45566871/1472186
- https://github.com/npm/npm/issues/17979#issuecomment-332701215