### PR TITLE
Can not access "Settings> editor" menu (404)

### DIFF
--- a/gulps/require.js
+++ b/gulps/require.js
@@ -50,6 +50,7 @@ module.exports = function(gulp, plugins) {
                 // Because settings views are loaded dynamically
                 'apps/settings/show/views/encryption',
                 'apps/settings/show/views/general',
+                'apps/settings/show/views/editor',
                 'apps/settings/show/views/importExport',
                 'apps/settings/show/views/keybindings',
                 'apps/settings/show/views/profiles',


### PR DESCRIPTION
404 is being generated because the built-in version does not include /setting/editor.js.