### PR TITLE
fix bug class causes sync button to overflow top bar over sidebar

### DIFF
--- a/app/scripts/components/navbar/template.html
+++ b/app/scripts/components/navbar/template.html
@@ -23,7 +23,7 @@
 
     <div class="navbar-right header--right navbar-btn">
         <% if (isSyncEnabled()) { %>
-        <button class="btn header--sbtn col-xs-6" id="header--sync">
+        <button class="btn header--sbtn" id="header--sync">
             <span id="header--sync--icon" class="icon-arrows"></span>
         </button>
         <% } %>

--- a/app/scripts/components/navbar/template.html
+++ b/app/scripts/components/navbar/template.html
@@ -24,7 +24,7 @@
     <div class="navbar-right header--right navbar-btn">
         <% if (isSyncEnabled()) { %>
         <button class="btn header--sbtn" id="header--sync">
-            <span id="header--sync--icon" class="icon-arrows"></span>
+            <span id="header--sync--icon"  class="icon-arrows"></span>
         </button>
         <% } %>
         <button id="header--add--tag" class="header--add btn btn-secondary">


### PR DESCRIPTION
Configuring dropbox will cause the sync button to appear, but the button is set to 50% width of the div, causing the new button to overflow over the sidebar list of notes.  
![overflow](https://user-images.githubusercontent.com/1466660/42671263-d5ddd3fc-8624-11e8-9236-193dd2670664.png)

Fix removes the class that causes this, making the buttons align nicely in a row.
![fix](https://user-images.githubusercontent.com/1466660/42671299-f52a9772-8624-11e8-9966-342d951d1326.png)
